### PR TITLE
[WEAV-114] 이상형 프로필 - 나이대 범위 입력 UI 구현

### DIFF
--- a/Projects/App/Sources/Navigation/NavigationStack.swift
+++ b/Projects/App/Sources/Navigation/NavigationStack.swift
@@ -42,6 +42,9 @@ extension PathType {
                 AuthRegionView()
             case .authName:
                 AuthNameInputView()
+                
+            case .dreamPartnerAgeRange:
+                DreamPartnerAgeView()
             }
         }
     }

--- a/Projects/Core/CommonKit/Sources/Path/PathTypes.swift
+++ b/Projects/Core/CommonKit/Sources/Path/PathTypes.swift
@@ -36,7 +36,9 @@ public enum PathType: Hashable {
         .signUp(.authJobOccupation),
         .signUp(.authName),
         .signUp(.authRegion),
-        .signUp(.authPhoneInput)
+        .signUp(.authPhoneInput),
+        
+        .signUp(.dreamPartnerAgeRange)
     ]
     #endif
     
@@ -57,6 +59,8 @@ public enum PathType: Hashable {
             case .authJobOccupation: return "내 직업 직군"
             case .authRegion: return "내 지역, 선호 지역 입력"
             case .authName: return "이름 입력"
+                
+            case .dreamPartnerAgeRange: return "이상형 나이대"
             }
         }
     }
@@ -74,6 +78,8 @@ public enum SignUpSubViewType: Hashable {
     case authJobOccupation
     case authRegion
     case authName
+    
+    case dreamPartnerAgeRange
     
     public static func == (lhs: SignUpSubViewType, rhs: SignUpSubViewType) -> Bool {
         return lhs.hashValue == rhs.hashValue
@@ -101,6 +107,9 @@ public enum SignUpSubViewType: Hashable {
             hasher.combine(8)
         case .authName:
             hasher.combine(9)
+            
+        case .dreamPartnerAgeRange:
+            hasher.combine(10)
         }
     }
 }

--- a/Projects/DesignSystem/DesignCore/Sources/VerifyCodeInput/VerifyCodeInputView.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/VerifyCodeInput/VerifyCodeInputView.swift
@@ -96,6 +96,10 @@ public struct VerifyCodeInputView: View {
     }
     
     private func getCharFromString(index: Int) -> String {
+        if verifyCode == "" {
+            return ""
+        }
+        
         if index >= verifyCode.count {
             return ""
         }

--- a/Projects/Domain/SignUpDomain/Sources/SignUpFormDomain.swift
+++ b/Projects/Domain/SignUpDomain/Sources/SignUpFormDomain.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpFormDomain.swift
+//  SignUpDomain
+//
+//  Created by 김지수 on 10/22/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import Foundation
+
+struct SignUpFormDomain {
+    let registerToken: String
+}

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeIntent.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeIntent.swift
@@ -1,0 +1,68 @@
+//
+//  DreamPartnerAgeIntent.swift
+//  SignUp
+//
+//  Created by 김지수 on 10/22/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import Foundation
+import CommonKit
+import CoreKit
+
+//MARK: - Intent
+class DreamPartnerAgeIntent {
+    private weak var model: DreamPartnerAgeModelActionable?
+    private let input: DataModel
+
+    // MARK: Life cycle
+    init(
+        model: DreamPartnerAgeModelActionable,
+        input: DataModel
+    ) {
+        self.input = input
+        self.model = model
+    }
+}
+
+//MARK: - Intentable
+extension DreamPartnerAgeIntent {
+    protocol Intentable {
+        // content
+        func onChangeUpperValue(value: String?)
+        func onChangeLowerValue(value: String?)
+        func onTapNextButton()
+        
+        // default
+        func onAppear()
+        func task() async
+    }
+    
+    struct DataModel {}
+}
+
+//MARK: - Intentable
+extension DreamPartnerAgeIntent: DreamPartnerAgeIntent.Intentable {
+    // default
+    func onAppear() {}
+    
+    func task() async {}
+    
+    // content
+    func onChangeUpperValue(value: String?) {
+        model?.setUpperValue(value: value)
+    }
+    func onChangeLowerValue(value: String?) {
+        model?.setLowerValue(value: value)
+    }
+    func onTapNextButton() {
+        Task {
+            await pushNextView()
+        }
+    }
+    
+    @MainActor
+    func pushNextView() {
+        
+    }
+}

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeModel.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeModel.swift
@@ -1,0 +1,91 @@
+//
+//  DreamPartnerAgeModel.swift
+//  SignUp
+//
+//  Created by 김지수 on 10/22/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import Foundation
+import CommonKit
+import CoreKit
+
+final class DreamPartnerAgeModel: ObservableObject {
+    
+    //MARK: Stateful
+    protocol Stateful {
+        // content
+        var upperValue: String? { get }
+        var lowerValue: String? { get }
+        var isValidated: Bool { get }
+        
+        // default
+        var isLoading: Bool { get }
+        
+        // error
+        var showErrorView: ErrorModel? { get }
+        var showErrorAlert: ErrorModel? { get }
+    }
+    
+    //MARK: State Properties
+    // content
+    var upperValue: String?
+    var lowerValue: String?
+    
+    @Published var isValidated: Bool = false
+    
+    // default
+    @Published var isLoading: Bool = false
+    
+    // error
+    @Published var showErrorView: ErrorModel?
+    @Published var showErrorAlert: ErrorModel?
+}
+
+extension DreamPartnerAgeModel: DreamPartnerAgeModel.Stateful {}
+
+//MARK: - Actionable
+protocol DreamPartnerAgeModelActionable: AnyObject {
+    // content
+    func setUpperValue(value: String?)
+    func setLowerValue(value: String?)
+    func setValidation(value: Bool)
+
+    // default
+    func setLoading(status: Bool)
+    
+    // error
+    func showErrorView(error: ErrorModel)
+    func showErrorAlert(error: ErrorModel)
+    func resetError()
+}
+
+extension DreamPartnerAgeModel: DreamPartnerAgeModelActionable {
+    // content
+    func setUpperValue(value: String?) {
+        upperValue = value
+    }
+    func setLowerValue(value: String?) {
+        lowerValue = value
+    }
+    func setValidation(value: Bool) {
+        isValidated = value
+    }
+    
+    // default
+    func setLoading(status: Bool) {
+        isLoading = status
+    }
+    
+    // error
+    func showErrorView(error: ErrorModel) {
+        showErrorView = error
+    }
+    func showErrorAlert(error: ErrorModel) {
+        showErrorAlert = error
+    }
+    func resetError() {
+        showErrorView = nil
+        showErrorAlert = nil
+    }
+}

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
@@ -126,7 +126,7 @@ public struct DreamPartnerAgeView: View {
             intent.onChangeUpperValue(value: upperValue)
         }
         .onChange(of: lowerValue) {
-            intent.onChangeUpperValue(value: lowerValue)
+            intent.onChangeLowerValue(value: lowerValue)
         }
         .task {
             await intent.task()

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
@@ -1,0 +1,216 @@
+//
+//  DreamPartnerAgeView.swift
+//  SignUp
+//
+//  Created by 김지수 on 10/22/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import SwiftUI
+import CoreKit
+import DesignCore
+import CommonKit
+
+enum AgeUpDownType {
+    case up
+    case down
+    
+    var imoji: String {
+        switch self {
+        case .up: "👆"
+        case .down: "👇"
+        }
+    }
+    
+    var text: String {
+        switch self {
+        case .up: "위"
+        case .down: "아래"
+        }
+    }
+    
+    var backgroundColor: Color {
+        switch self {
+        case .up: DesignCore.Colors.green50
+        case .down: DesignCore.Colors.pink50
+        }
+    }
+    
+    var borderColor: Color {
+        switch self {
+        case .up: .init(hex: 0xA1BA91)
+        case .down: .init(hex: 0xE6B1C4)
+        }
+    }
+    
+    var textColor: Color {
+        switch self {
+        case .up: DesignCore.Colors.green500
+        case .down: DesignCore.Colors.pink500
+        }
+    }
+}
+
+public struct DreamPartnerAgeView: View {
+    
+    @StateObject var container: MVIContainer<DreamPartnerAgeIntent.Intentable, DreamPartnerAgeModel.Stateful>
+    
+    private var intent: DreamPartnerAgeIntent.Intentable { container.intent }
+    private var state: DreamPartnerAgeModel.Stateful { container.model }
+    
+    public init() {
+        let model = DreamPartnerAgeModel()
+        let intent = DreamPartnerAgeIntent(
+            model: model,
+            input: .init()
+        )
+        let container = MVIContainer(
+            intent: intent as DreamPartnerAgeIntent.Intentable,
+            model: model as DreamPartnerAgeModel.Stateful,
+            modelChangePublisher: model.objectWillChange
+        )
+        self._container = StateObject(wrappedValue: container)
+    }
+    
+    @State private var upperValue: String?
+    @State private var lowerValue: String?
+    @State private var showUpperPicker = true
+    @State private var showLowerPicker = false
+    
+    public var body: some View {
+        ZStack {
+            VStack {
+                ProfileInputTemplatedView(
+                    currentPage: 1,
+                    maxPage: 3,
+                    subMessage: "연상, 동갑, 연하... 최대한 맞춰줄께요!",
+                    mainMessage: "상대의 나이대는\n어느 정도가 좋을까요?"
+                ) {
+                    VStack {
+                        ageUpDownView(type: .up)
+                            .onTapGesture {
+                                showUpperPicker = true
+                                showLowerPicker = false
+                            }
+                        ageUpDownView(type: .down)
+                            .onTapGesture {
+                                showUpperPicker = false
+                                showLowerPicker = true
+                            }
+                    }
+                }
+                
+                Spacer()
+            }
+            if showUpperPicker || showLowerPicker {
+                VStack {
+                    Spacer()
+                    BottomSheetPickerView(
+                        selectedValue: showUpperPicker ? $upperValue : $lowerValue
+                    )
+                    .padding(.bottom, 90)
+                    .frame(height: 300)
+                }
+                .transition(.move(edge: .bottom))
+                .ignoresSafeArea()
+            }
+            
+            VStack {
+                Spacer()
+                CTABottomButton(title: "다음") {
+                        
+                }
+            }
+        }
+        .onChange(of: upperValue) {
+            intent.onChangeUpperValue(value: upperValue)
+        }
+        .onChange(of: lowerValue) {
+            intent.onChangeUpperValue(value: lowerValue)
+        }
+        .task {
+            await intent.task()
+        }
+        .onAppear {
+            intent.onAppear()
+        }
+        .ignoresSafeArea(.keyboard)
+        .textureBackground()
+        .setPopNavigation {
+            AppCoordinator.shared.pop()
+        }
+        .setLoading(state.isLoading)
+    }
+    
+    @ViewBuilder
+    func ageUpDownView(type: AgeUpDownType) -> some View {
+        HStack(spacing: 8) {
+            HStack {
+                Text(type.imoji)
+                Text("내 나이보다")
+                Text(type.text)
+                Text("로")
+            }
+            Spacer()
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .inset(by: 4)
+                    .stroke(
+                        borderColor(type: type),
+                        lineWidth: 10
+                    )
+                    .fill(type.backgroundColor)
+                    .shadow(.default)
+                switch type {
+                case .up:
+                    Text(upperValue ?? "-")
+                        .pretendard(weight: ._600, size: 36)
+                        .foregroundStyle(type.textColor)
+                case .down:
+                    Text(lowerValue ?? "-")
+                        .pretendard(weight: ._600, size: 36)
+                        .foregroundStyle(type.textColor)
+                }
+            }
+            .frame(width: 92, height: 62)
+            .padding(.horizontal, 2)
+            
+            Text("살")
+        }
+        .padding(.horizontal, 8)
+        .foregroundStyle(DesignCore.Colors.grey300)
+        .typography(.semibold_18)
+    }
+    
+    func borderColor(type: AgeUpDownType) -> Color {
+        switch type {
+        case .up: showUpperPicker ? type.borderColor : .white
+        case .down: showLowerPicker ? type.borderColor : .white
+        }
+    }
+}
+
+struct BottomSheetPickerView: View {
+    @Binding var selectedValue: String?
+    
+    var body: some View {
+        Picker("숫자 선택", selection: $selectedValue) {
+            Text("상관없어요")
+                .tag(String?.none)
+            ForEach(0...15, id: \.self) { number in
+                Text("\(number)")
+                    .tag(String?(String(number)))
+            }
+        }
+        .pickerStyle(.wheel)
+        .padding(.bottom)
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+    }
+}
+
+#Preview {
+    NavigationView {
+        DreamPartnerAgeView()
+    }
+}


### PR DESCRIPTION
## 구현사항
- 이상형 프로필 입력 - 나이대 입력
- Picker 이용해 구현

## 스크린샷(선택)
|나이 범위 입력|
|:---:|
|<img src="https://github.com/user-attachments/assets/85161826-bdf5-499b-8ba4-55441ce4ae45" width="400">|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 회원가입 프로세스에서 꿈의 파트너 나이 범위를 선택할 수 있는 새로운 뷰 추가.
	- 사용자 상호작용을 관리하는 `DreamPartnerAgeIntent` 클래스 도입.
	- 나이 선택을 위한 SwiftUI 뷰 `DreamPartnerAgeView` 추가.
	- 상태 관리를 위한 `DreamPartnerAgeModel` 클래스 도입.
- **버그 수정**
	- 비어 있는 인증 코드에 대한 처리 로직 개선.
- **문서화**
	- 새로운 구조체 `SignUpFormDomain` 문서화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->