### PR TITLE
[WEAV-117] Debug View 상세 구현, Transition 처리 보완

### DIFF
--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -25,5 +25,11 @@ jobs:
       
     - name: Run unit tests
       run: |
-        xcodebuild test -scheme three-days-UnitTest -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' | tee result.log
+        set -o pipefail && xcodebuild test \
+          -scheme three-days-UnitTest \
+          -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+          | tee result.log
+        if grep -q "** TEST FAILED **" result.log; then
+          exit 1
+        fi
       continue-on-error: false

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Run unit tests
       run: |
         xcodebuild test -scheme three-days-UnitTest -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' | tee result.log
-      continue-on-error: true
+      continue-on-error: false

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -33,3 +33,11 @@ jobs:
           exit 1
         fi
       continue-on-error: false
+
+    - name: Failure notification to Discord
+      if: failure()
+      run: |
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{\"content\": null, \"embeds\": [{\"title\": \"iOS 유닛 테스트 실패..?\", \"description\": \"Actor: ${{ github.actor }}\nBranch: ${{ github.head_ref }}\nCommit: ${{ github.event.pull_request.head.sha }}\n\n💥 잉?!\", \"color\": 16711741}]}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -22,7 +22,8 @@ let infoPlist = InfoPlist.extendingDefault(
 let appDependencies: [TargetDependency] = [
     .project(target: .home),
     .project(target: .signUp),
-    .project(target: .designPreview)
+    .project(target: .designPreview),
+    .external(.navigationTransitions)
 ]
 
 let project: Project = .make(

--- a/Projects/App/Sources/Debug/AuthInfoView.swift
+++ b/Projects/App/Sources/Debug/AuthInfoView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import DesignCore
 import CoreKit
+import CommonKit
 
 #if DEBUG || STAGING
 struct TableInfoModel: Identifiable {
@@ -26,9 +27,9 @@ enum Sections: CaseIterable {
     var sectionTitle: String {
         switch self {
         case .authInfo: "토큰 정보"
-        case .userInfo: "유저 정보(TEMP)"
-        case .userProfile: "프로필 정보(TEMP)"
-        case .dreamPartnerInfo: "이상형 정보(TEMP)"
+        case .userInfo: "유저 정보"
+        case .userProfile: "프로필 정보"
+        case .dreamPartnerInfo: "이상형 정보"
         }
     }
     
@@ -57,40 +58,59 @@ enum Sections: CaseIterable {
                 ),
                 TableInfoModel(
                     title: "이름",
-                    value: "홍길동"
+                    value: AppCoordinator.shared.userInfo?.name ?? "null"
                 ),
                 TableInfoModel(
                     title: "휴대폰 번호",
-                    value: "010-1234-1234"
+                    value: AppCoordinator.shared.userInfo?.phone ?? "null"
                 )
             ]
         case .userProfile:
             [
                 TableInfoModel(
                     title: "출생년도",
-                    value: "1996"
+                    value: AppCoordinator.shared.userInfo?.profile.birthYear == nil ? "null" : String((AppCoordinator.shared.userInfo?.profile.birthYear)!)
                 ),
                 TableInfoModel(
                     title: "회사 ID",
-                    value: UUID().uuidString
+                    value: AppCoordinator.shared.userInfo?.profile.companyId ?? "null"
                 ),
                 TableInfoModel(
                     title: "성별",
-                    value: "MALE"
+                    value: AppCoordinator.shared.userInfo?.profile.gender.rawValue ?? "null"
                 ),
                 TableInfoModel(
                     title: "직군정보",
-                    value: UUID().uuidString
+                    value: AppCoordinator.shared.userInfo?.profile.jobOccupation ?? "null"
                 ),
                 TableInfoModel(
                     title: "활동지역 ID",
-                    value: [UUID(), UUID(), UUID()]
-                        .map { $0.uuidString }
-                        .joined(separator: "\n")
+                    value: AppCoordinator.shared.userInfo?.profile.locations != nil ? AppCoordinator.shared.userInfo!.profile.locations
+                        .compactMap { $0 }
+                        .joined(separator: "\n") : "null"
                 )
             ]
         case .dreamPartnerInfo:
-            []
+            [
+                TableInfoModel(
+                    title: "출생년도 범위",
+                    value: "\(AppCoordinator.shared.userInfo?.dreamPartner.lowerBirthYear ?? 0) ~ \(AppCoordinator.shared.userInfo?.dreamPartner.upperBirthYear ?? 0)"
+                ),
+                TableInfoModel(
+                    title: "같은 회사 소개 여부",
+                    value: AppCoordinator.shared.userInfo?.dreamPartner.allowSameCompany == nil ? "null" : String((AppCoordinator.shared.userInfo?.dreamPartner.allowSameCompany)!)
+                ),
+                TableInfoModel(
+                    title: "거리",
+                    value: AppCoordinator.shared.userInfo?.dreamPartner.distanceType.description ?? "null"
+                ),
+                TableInfoModel(
+                    title: "직군정보",
+                    value: AppCoordinator.shared.userInfo?.dreamPartner.jobOccupations != nil ? AppCoordinator.shared.userInfo!.dreamPartner.jobOccupations
+                        .compactMap { $0 }
+                        .joined(separator: "\n") : "null"
+                )
+            ]
         }
     }
 }

--- a/Projects/App/Sources/Splash/SplashAnimatedView.swift
+++ b/Projects/App/Sources/Splash/SplashAnimatedView.swift
@@ -116,9 +116,7 @@ struct SplashAnimatedView: View {
                 isActive: true,
                 isShowLetter: $showLetterAnimation
             ) {
-                AppCoordinator.shared.navigationStack.append(
-                    .signUp(.authPhoneInput)
-                )
+                AppCoordinator.shared.changeRootView(.signUp(.authPhoneInput))
             }
             .frame(height: 70)
             .padding(.horizontal, 50)
@@ -179,7 +177,7 @@ struct SplashAnimatedView: View {
     
     @MainActor
     private func pushToHomeView() {
-        AppCoordinator.shared.push(.authDebug)
+        AppCoordinator.shared.changeRootView(.authDebug)
     }
     
     private func updateIconStates(for step: SplashAnimationStep) {

--- a/Projects/App/Sources/Splash/SplashAnimatedView.swift
+++ b/Projects/App/Sources/Splash/SplashAnimatedView.swift
@@ -44,6 +44,7 @@ struct SplashAnimatedView: View {
     @State private var cycleCompleted = false
     @State private var otherViewOpacity: CGFloat = 0.0
     @State private var showLetterAnimation = false
+    @State private var viewDisappeared: Bool = false
     @State private var iconStates: [IconState] = [
         IconState(
             id: 0,
@@ -130,10 +131,15 @@ struct SplashAnimatedView: View {
         .task {
             await runSingleCycle()
         }
+        .onDisappear {
+            viewDisappeared = true
+        }
     }
     
     private func runSingleCycle() async {
+        guard !cycleCompleted else { return }
         for step in SplashAnimationStep.allCases.dropFirst() {
+            if viewDisappeared { return }
             guard !cycleCompleted else { break }
             if step == .fifth {
                 // auth 상태 체크
@@ -142,7 +148,7 @@ struct SplashAnimatedView: View {
                 /// 로그아웃 -> 애니메이션 계속진행
                 if isAuthorized {
                     try? await Task.sleep(for: .seconds(1))
-                    await pushToHomeView()
+                    pushToHomeView()
                     break
                 }
             }

--- a/Projects/App/Sources/ThreeDaysApp.swift
+++ b/Projects/App/Sources/ThreeDaysApp.swift
@@ -32,7 +32,6 @@ struct ThreeDaysApp: App {
                     for: PathType.self
                 ) { feature in
                     feature.view
-                        .transition(.opacity)
                 }
         }
         .navigationTransition(

--- a/Projects/App/Sources/ThreeDaysApp.swift
+++ b/Projects/App/Sources/ThreeDaysApp.swift
@@ -3,6 +3,7 @@ import DesignCore
 import DesignPreview
 import CommonKit
 import Home
+import NavigationTransitions
 
 @main
 struct ThreeDaysApp: App {
@@ -31,8 +32,13 @@ struct ThreeDaysApp: App {
                     for: PathType.self
                 ) { feature in
                     feature.view
+                        .transition(.opacity)
                 }
         }
+        .navigationTransition(
+            AppCoordinator.shared.needFadeTransition ? .fade(.cross) : .slide,
+            interactivity: AppCoordinator.shared.isRootView ? .disabled : .pan
+        )
     }
 
     #if STAGING || DEBUG

--- a/Projects/Core/CommonKit/Sources/AppCoordinator.swift
+++ b/Projects/Core/CommonKit/Sources/AppCoordinator.swift
@@ -20,8 +20,8 @@ public final class AppCoordinator: ObservableObject {
     }
     
     //MARK: - Properties
-    @Published public var authState: AuthState = .none
-    @Published public var userInfo: UserInfo?
+    public var authState: AuthState = .none
+    public var userInfo: UserInfo?
     @Published public var navigationStack: [PathType] = [.intro]
     let authService = AuthService.shared
     
@@ -31,7 +31,9 @@ public final class AppCoordinator: ObservableObject {
             DispatchQueue.main.async {
                 self?.authState = state
                 if state == .loggedOut {
-                    self?.navigationStack = [.intro]
+                    if self?.navigationStack != [.intro] {
+                        self?.navigationStack = [.intro]
+                    }
                     self?.userInfo = nil
                 }
             }
@@ -69,6 +71,10 @@ public final class AppCoordinator: ObservableObject {
                 if refreshToken == nil {
                     refreshToken = TokenManager.refreshToken
                 }
+                
+                print("👉 accessToken: \(TokenManager.accessToken ?? "null")")
+                print("👉 refreshToken: \(TokenManager.refreshToken ?? "null")")
+                
                 guard accessToken != nil && accessToken != "" else {
                     await MainActor.run {
                         AuthState.change(.loggedOut)

--- a/Projects/Core/CommonKit/Sources/AppCoordinator.swift
+++ b/Projects/Core/CommonKit/Sources/AppCoordinator.swift
@@ -22,8 +22,13 @@ public final class AppCoordinator: ObservableObject {
     //MARK: - Properties
     public var authState: AuthState = .none
     public var userInfo: UserInfo?
+    public var needFadeTransition: Bool = false
     @Published public var navigationStack: [PathType] = [.intro]
     let authService = AuthService.shared
+    
+    public var isRootView: Bool {
+        navigationStack.count == 1
+    }
     
     //MARK: - Methods
     private func setup() {
@@ -42,11 +47,13 @@ public final class AppCoordinator: ObservableObject {
     
     @MainActor
     public func changeRootView(_ path: PathType) {
+        needFadeTransition = true
         navigationStack = [path]
     }
     
     @MainActor
     public func push(_ path: PathType) {
+        needFadeTransition = false
         navigationStack.append(path)
     }
     

--- a/Projects/Core/NetworkKit/Sources/NetworkCore/Middleware/LogMiddleWare.swift
+++ b/Projects/Core/NetworkKit/Sources/NetworkCore/Middleware/LogMiddleWare.swift
@@ -16,7 +16,7 @@ import Foundation
 import HTTPTypes
 
 actor LoggingMiddleware {
-    package init() {}
+    init() {}
 }
 
 extension LoggingMiddleware: ClientMiddleware {
@@ -45,12 +45,8 @@ extension LoggingMiddleware: ClientMiddleware {
     
     private func copyBody(_ body: HTTPBody?) async throws -> (Data?, HTTPBody?) {
         guard let body = body else { return (nil, nil) }
-        
-        if case .known(let length) = body.length {
-            let data = try await Data(collecting: body, upTo: Int(length))
-            return (data, HTTPBody(data))
-        }
-        return (nil, body)
+        let data = try await Data(collecting: body, upTo: 10 * 1024 * 1024)
+        return (data, HTTPBody(data))
     }
 }
 

--- a/Projects/Features/SignUp/Sources/AuthSignUp/AuthPhoneVerify/AuthPhoneVerifyIntent.swift
+++ b/Projects/Features/SignUp/Sources/AuthSignUp/AuthPhoneVerify/AuthPhoneVerifyIntent.swift
@@ -131,7 +131,7 @@ extension AuthPhoneVerifyIntent: AuthPhoneVerifyIntent.Intentable {
                     input: payload
                 )
         )
-        case .EXISTING: return .home
+        case .EXISTING: return .authDebug
         }
     }
     

--- a/Projects/Features/SignUp/UnitTest/AuthPhoneVerifyTest.swift
+++ b/Projects/Features/SignUp/UnitTest/AuthPhoneVerifyTest.swift
@@ -62,7 +62,7 @@ class AuthPhoneVerifyTest: XCTestCase {
     
     func testVerificationResult() {
         let homePath = intent.getNextPath(userType: .EXISTING)
-        XCTAssertEqual(homePath, PathType.home)
+        XCTAssertEqual(homePath, PathType.authDebug)
         
         let signUpProcessPath = intent.getNextPath(userType: .NEW)
         XCTAssertEqual(signUpProcessPath, PathType.signUp(.authAgreement(input: .mock)))

--- a/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
+++ b/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
@@ -149,7 +149,7 @@ public enum DreamPartnerDistanceType: CaseIterable {
     }
 }
 
-public enum GenderType: CaseIterable {
+public enum GenderType: String, CaseIterable {
     case male
     case female
     

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -44,6 +44,24 @@
         "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
         "version" : "1.0.2"
       }
+    },
+    {
+      "identity" : "swiftui-introspect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/siteline/swiftui-introspect",
+      "state" : {
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation-transitions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/davdroman/swiftui-navigation-transitions.git",
+      "state" : {
+        "revision" : "76ae9c621422a1f38c30a07c8b7636994b669484",
+        "version" : "0.14.0"
+      }
     }
   ],
   "version" : 2

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,7 +8,15 @@ import PackageDescription
         // Customize the product types for specific package product
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,] 
-        productTypes: [:],
+        productTypes: [
+            "Animation": .framework,
+            "Animator": .framework,
+            "AtomicTransition": .framework,
+            "NavigationTransition": .framework,
+            "NavigationTransitions": .framework,
+            "RuntimeAssociation": .framework,
+            "RuntimeSwizzling": .framework
+        ],
         baseSettings: .settings(
             configurations: [
                 .debug(name: .debug),
@@ -27,5 +35,9 @@ let package = Package(
             url: "https://github.com/kean/Nuke.git",
             exact: "12.8.0"
         ),
+        .package(
+            url: "https://github.com/davdroman/swiftui-navigation-transitions.git",
+            exact: "0.14.0"
+        )
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Dependency+extensions.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+extensions.swift
@@ -10,6 +10,7 @@ import ProjectDescription
 public enum ExternalDependency: String {
     case nuke = "Nuke"
     case openapiGenerated = "OpenapiGenerated"
+    case navigationTransitions = "NavigationTransitions"
     
     var name: String {
         return self.rawValue


### PR DESCRIPTION
## 구현사항
- Auth 상태 debug 뷰 상세 구현
- Navigation Stack 의 자연스러운 전환 처리를 위한 [SwiftUI Transitions](https://github.com/davdroman/swiftui-navigation-transitions) 라이브러리 추가 
- Root 로 이동하는 경우에는 fade 애니메이션이 적용되도록 구현

## 고민(선택)
- Navigation Stack 의 Transition 애니메이션 처리에 대해 고민이 많았음
  - 애니메이션 커스텀이 자유롭지는 못한듯 ..
- 결국 라이브러리를 추가해 동적으로 처리하도록 했으나, 이게 맞을지는 좀 더 고민해봐야겠음
  - iOS 18 에 transition 관련 api 를 적용하는 것이 가장 좋아보이긴 함 ..

## 스크린샷(선택)
|타이틀1|
|:---:|
|<img src="https://github.com/user-attachments/assets/0f1b3718-b186-40b5-ae13-2b8c9b3c7b69" width="400">|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 외부 네비게이션 전환 기능 추가로 사용자 경험 향상.
	- 사용자 정보 동적 표시 기능 개선.
	- 기존 사용자에 대한 전화 인증 후 네비게이션 경로 변경.
	- 애플리케이션의 전환 효과에 대한 더 나은 제어 추가.

- **버그 수정**
	- 유닛 테스트 실패 시 워크플로우 중단 설정 변경.

- **문서화**
	- 패키지 설정 및 의존성 관리 개선.

- **리팩토링**
	- 상태 관리 및 전환 로직 개선.

- **스타일**
	- 애니메이션 전환 효과 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->