### PR TITLE
[WEAV-136] ToolTip AttibutedString 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ Derived/
 Tuist/.build
 Projects/Core/CoreKit/Sources/Secret.swift
 graph.png
+OpenApiGenerator/.build

--- a/Projects/DesignSystem/DesignCore/Sources/Tooltip/ToolTip.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/Tooltip/ToolTip.swift
@@ -9,37 +9,63 @@
 import SwiftUI
 
 extension View {
-    public func tooltip(message: String, offset: CGFloat) -> some View {
+    public func tooltip(message: String?, offset: CGFloat) -> some View {
+        return modifier(ToolTipViewModifier(message: message, offset: offset))
+    }
+    
+    public func tooltip(message: AttributedString?, offset: CGFloat) -> some View {
         return modifier(ToolTipViewModifier(message: message, offset: offset))
     }
 }
 
 struct ToolTipViewModifier: ViewModifier {
-    let message: String
+    let message: AttributedString?
     let offset: CGFloat
+    
+    init(
+        message: AttributedString?,
+        offset: CGFloat
+    ) {
+        self.message = message
+        self.offset = offset
+    }
+    
+    init(
+        message: String?,
+        offset: CGFloat
+    ) {
+        if let message {
+            self.message = .init(stringLiteral: message)
+        } else {
+            self.message = nil
+        }
+        self.offset = offset
+    }
     
     func body(content: Content) -> some View {
         content
             .overlay {
-                Text(message)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    .typography(.regular_12)
-                    .foregroundStyle(.white)
-                    .multilineTextAlignment(.center)
-                    .background {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(DesignCore.Colors.grey400)
-                            VStack {
-                                Spacer()
-                                InvertedTriangle()
+                if let message {
+                    Text(message)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .typography(.regular_12)
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .background {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(DesignCore.Colors.grey400)
+                                VStack {
+                                    Spacer()
+                                    InvertedTriangle()
+                                }
+                                .offset(y: 12)
                             }
-                            .offset(y: 12)
                         }
-                    }
-                    .frame(width: 300)
-                    .offset(y: -offset)
+//                        .frame(width: 300)
+                        .offset(y: -offset)
+                }
             }
     }
 }

--- a/Projects/Features/Home/UnitTest/WidgetUnitTest.swift
+++ b/Projects/Features/Home/UnitTest/WidgetUnitTest.swift
@@ -22,7 +22,7 @@ struct WidgetUnitTest {
         self.selectionState = WidgetSelectionModel()
         self.selectionIntent = WidgetSelectionIntent(
             model: selectionState,
-            input: .init(successHandler: {})
+            input: .init()
         )
         
         self.writeState = WidgetWritingModel()
@@ -30,10 +30,7 @@ struct WidgetUnitTest {
             model: writeState,
             input: .init(
                 widgetType: .body,
-                content: nil,
-                successHandler: {
-                    
-                }
+                content: nil
             ),
             service: ProfileServiceMock()
         )

--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputIntent.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputIntent.swift
@@ -34,7 +34,7 @@ extension AuthProfileAgeInputIntent {
         func onFocusChanged(_ value: Bool)
         func onTapNextButton(_ year: String)
         func onYearChanged(_ year: String)
-        func toggleToopTip()
+        func toggleToolTip()
         
         // default
         func onAppear()
@@ -76,7 +76,7 @@ extension AuthProfileAgeInputIntent: AuthProfileAgeInputIntent.Intentable {
             )
         }
     }
-    func toggleToopTip() {
+    func toggleToolTip() {
         model?.toggleToolTip()
     }
 }

--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputIntent.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputIntent.swift
@@ -34,6 +34,7 @@ extension AuthProfileAgeInputIntent {
         func onFocusChanged(_ value: Bool)
         func onTapNextButton(_ year: String)
         func onYearChanged(_ year: String)
+        func toggleToopTip()
         
         // default
         func onAppear()
@@ -74,5 +75,8 @@ extension AuthProfileAgeInputIntent: AuthProfileAgeInputIntent.Intentable {
                 .signUp(.authCompany(input: payload))
             )
         }
+    }
+    func toggleToopTip() {
+        model?.toggleToolTip()
     }
 }

--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputModel.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputModel.swift
@@ -21,6 +21,7 @@ final class AuthProfileAgeInputModel: ObservableObject {
         var isFocused: Bool { get }
         var isValidated: Bool { get }
         var targetGender: GenderType { get }
+        var isShowToolTip: Bool { get }
         
         // default
         var isLoading: Bool { get }
@@ -37,6 +38,7 @@ final class AuthProfileAgeInputModel: ObservableObject {
     @Published var birthYear = String()
     @Published var isFocused: Bool = false
     @Published var targetGender: GenderType = .female
+    @Published var isShowToolTip: Bool = false
     
     // default
     @Published var isLoading: Bool = false
@@ -55,6 +57,7 @@ protocol AuthProfileAgeInputModelActionable: AnyObject {
     func setFocuse(_ value: Bool)
     func setValidation(value: Bool)
     func setTargetGender(_ gender: GenderType)
+    func toggleToolTip()
 
     // default
     func setLoading(status: Bool)
@@ -78,6 +81,9 @@ extension AuthProfileAgeInputModel: AuthProfileAgeInputModelActionable {
     }
     func setTargetGender(_ gender: GenderType) {
         targetGender = gender
+    }
+    func toggleToolTip() {
+        isShowToolTip.toggle()
     }
     // default
     func setLoading(status: Bool) {

--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputView.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputView.swift
@@ -103,7 +103,7 @@ public struct AuthProfileAgeInputView: View {
                     
                     Button(action: {
                         withAnimation {
-                            intent.toggleToopTip()
+                            intent.toggleToolTip()
                         }
                     }, label: {
                         HStack(spacing: 4) {
@@ -143,7 +143,7 @@ public struct AuthProfileAgeInputView: View {
         .setLoading(state.isLoading)
         .onTapGesture {
             if state.isShowToolTip {
-                intent.toggleToopTip()
+                intent.toggleToolTip()
             }
         }
     }

--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputView.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthProfileAge/AuthProfileAgeInputView.swift
@@ -37,12 +37,32 @@ public struct AuthProfileAgeInputView: View {
         self._container = StateObject(wrappedValue: container)
     }
     
+    private var tooltipMessage: AttributedString {
+        let text = """
+        2024년 기준으로 2004년생(만 20살)부터
+        1989년생(만 35살)까지 가입할 수 있어요
+        """
+
+        var attributedString = AttributedString(text)
+        let boldRanges = [
+            text.range(of: "2004년생(만 20살)부터"),
+            text.range(of: "1989년생(만 35살)")
+        ].compactMap { $0 }
+
+        boldRanges.forEach { range in
+            let attributedRange = attributedString.range(of: text[range])!
+            attributedString[attributedRange].inlinePresentationIntent = .stronglyEmphasized
+        }
+
+        return attributedString
+    }
+    
     public var body: some View {
         VStack {
             ProfileInputTemplatedView(
                 currentPage: 2,
                 maxPage: 5,
-                subMessage: "좋은 \(state.targetGender) 소개시켜 드릴께요!",
+                subMessage: "좋은 \(state.targetGender.name)분 소개시켜 드릴께요!",
                 mainMessage: "당신의 나이는 무엇인가요?"
             ) {
                 VStack {
@@ -82,7 +102,9 @@ public struct AuthProfileAgeInputView: View {
                     .frame(height: 92)
                     
                     Button(action: {
-                        
+                        withAnimation {
+                            intent.toggleToopTip()
+                        }
                     }, label: {
                         HStack(spacing: 4) {
                             DesignCore.Images.iconInformation.image
@@ -94,6 +116,7 @@ public struct AuthProfileAgeInputView: View {
                     .padding(.top, 20)
                 }
                 .padding(.top, 8)
+                .tooltip(message: state.isShowToolTip ? tooltipMessage : nil, offset: 0)
             }
             
             Spacer()
@@ -118,6 +141,11 @@ public struct AuthProfileAgeInputView: View {
             
         }
         .setLoading(state.isLoading)
+        .onTapGesture {
+            if state.isShowToolTip {
+                intent.toggleToopTip()
+            }
+        }
     }
 }
 

--- a/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
+++ b/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
@@ -153,10 +153,17 @@ public enum GenderType: String, CaseIterable {
     case male
     case female
     
-    var toDto: Components.Schemas.Gender {
+    public var toDto: Components.Schemas.Gender {
         switch self {
         case .male: .MALE
         case .female: .FEMALE
+        }
+    }
+    
+    public var name: String {
+        switch self {
+        case .male: "남성"
+        case .female: "여성"
         }
     }
 }


### PR DESCRIPTION
## 구현사항
- 부분 bold 적용을 위해 ToolTip 컴포넌트에 AttributedString 적용 가능하도록 수정
- 가입 연령 툴팁 적용

## 스크린샷(선택)
|가입 연령 안내 툴팁|
|:---:|
|<img src="https://github.com/user-attachments/assets/aee03535-820d-4086-be6d-ad109375b813" width="400">|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 툴팁 기능이 추가되어 사용자 등록을 위한 연령 관련 정보를 제공합니다.
	- 툴팁 메시지가 문자열 및 서식 있는 문자열 모두를 지원하도록 업데이트되었습니다.
	- 툴팁의 가시성을 토글하는 기능이 추가되었습니다.
	- 성별 유형의 열거형에 대한 새로운 공개 속성 `name`이 추가되었습니다.

- **버그 수정**
	- `GenderType` 열거형의 `toDto` 속성 접근 수준이 변경되어 외부에서 접근 가능해졌습니다.

- **문서화**
	- 툴팁 관련 메시지 및 가시성 관리에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->