### PR TITLE
[WEAV-134] 같은회사 소개 안받기 옵션 API 추가

### DIFF
--- a/Projects/Features/SignUp/Sources/ProfileInput/AuthCompany/AuthCompanyIntent.swift
+++ b/Projects/Features/SignUp/Sources/ProfileInput/AuthCompany/AuthCompanyIntent.swift
@@ -146,6 +146,7 @@ extension AuthCompanyIntent: AuthCompanyIntent.Intentable {
         Task {
             var payload = input.input
             payload.profile?.companyId = state.selectedCompany?.id
+            payload.dreamPartner?.allowSameCompany = state.sameCompanyMatchingAvailable
             await pushNextView(payload: payload)
         }
     }

--- a/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
+++ b/Projects/Model/Model/Sources/SignUp/Domain/SignUpFormDomain.swift
@@ -94,6 +94,7 @@ public struct SignUpDreamPartnerDomain {
     public var lowerBirthYearGap: Int?
     public var upperBirthYearGap: Int?
     public var jobOccupations: [String]
+    public var allowSameCompany: Bool?
     public var distanceType: DreamPartnerDistanceType?
     
     var toDto: Components.Schemas.UserDesiredPartner? {
@@ -110,7 +111,8 @@ public struct SignUpDreamPartnerDomain {
                 end: upperBirthYearGap
             ),
             jobOccupations: jobOccupations,
-            preferDistance: distanceType.toDto
+            preferDistance: distanceType.toDto,
+            allowSameCompany: allowSameCompany
         )
     }
     
@@ -118,12 +120,14 @@ public struct SignUpDreamPartnerDomain {
         lowerBirthYearGap: Int? = nil,
         upperBirthYearGap: Int? = nil,
         jobOccupations: [String],
-        distanceType: DreamPartnerDistanceType? = nil
+        distanceType: DreamPartnerDistanceType? = nil,
+        allowSameCompany: Bool? = nil
     ) {
         self.lowerBirthYearGap = lowerBirthYearGap
         self.upperBirthYearGap = upperBirthYearGap
         self.jobOccupations = jobOccupations
         self.distanceType = distanceType
+        self.allowSameCompany = allowSameCompany
     }
 }
 


### PR DESCRIPTION
## 구현사항
- 같은 회사 소개 안받기 옵션 API 필드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 사용자가 동일 회사와 매칭되는 것에 대한 동의를 표현할 수 있는 기능 추가.
	- 회원가입 프로세스에서 다음 단계로 진행할 때 해당 동의 상태가 포함됨.

- **버그 수정**
	- 데이터 구조에서 `allowSameCompany` 속성을 추가하여 회원가입 도메인의 기능 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->