### PR TITLE
[WEAV-148] 이상형 프로필 수정 - 선호 연령대

### DIFF
--- a/Projects/App/Sources/Navigation/NavigationStack.swift
+++ b/Projects/App/Sources/Navigation/NavigationStack.swift
@@ -83,7 +83,7 @@ extension PathType {
         case .editDreamPartner(let subView):
             switch subView {
             case .ageRange(let userInfo):
-                EmptyView()
+                EditDateProfileAgeRangeView(userInfo: userInfo)
             case .jobOccupation(let userInfo):
                 EmptyView()
             case .distance(let userInfo):

--- a/Projects/Core/CommonKit/Sources/AppCoordinator.swift
+++ b/Projects/Core/CommonKit/Sources/AppCoordinator.swift
@@ -34,6 +34,8 @@ public final class AppCoordinator: ObservableObject {
     private func setup() {
         AuthState.changeHandler = { [weak self] state in
             DispatchQueue.main.async {
+                guard self?.authState != state else { return }
+                print("⚠️ Auth 상태 \(state)로 변경")
                 self?.authState = state
                 if state == .loggedOut {
                     if self?.navigationStack != [.intro] {

--- a/Projects/Core/CoreKit/Sources/AuthState.swift
+++ b/Projects/Core/CoreKit/Sources/AuthState.swift
@@ -17,7 +17,6 @@ public enum AuthState {
 public extension AuthState {
     static var changeHandler: ((AuthState) -> Void)?
     static func change(_ state: AuthState) {
-        print("⚠️ Auth 상태 \(state)로 변경")
         if state == .loggedOut {
             TokenManager.accessToken = nil
             TokenManager.refreshToken = nil

--- a/Projects/Core/NetworkKit/Sources/ProfileService/ProfileService.swift
+++ b/Projects/Core/NetworkKit/Sources/ProfileService/ProfileService.swift
@@ -22,6 +22,8 @@ public protocol ProfileServiceProtocol {
     ) async throws
     
     func requestPutUserInfo(userInfo: UserInfo) async throws
+    
+    func requestPutPartnerInfo(userInfo: UserInfo) async throws
 }
 
 public final class ProfileService {
@@ -74,5 +76,10 @@ extension ProfileService: ProfileServiceProtocol {
             )
         )
         _ = try result.ok
+    }
+    
+    public func requestPutPartnerInfo(userInfo: UserInfo) async throws {
+        // TODO: API 구현
+        return
     }
 }

--- a/Projects/Core/NetworkKit/Sources/ProfileService/ProfileServiceMock.swift
+++ b/Projects/Core/NetworkKit/Sources/ProfileService/ProfileServiceMock.swift
@@ -33,4 +33,9 @@ public final class ProfileServiceMock: ProfileServiceProtocol {
         print("✅ [ProfileServiceMock] requestPutUserInfo 성공!")
         return
     }
+    
+    public func requestPutPartnerInfo(userInfo: UserInfo) async throws {
+        print("✅ [ProfileServiceMock] requestPutPartnerInfo 성공!")
+        return
+    }
 }

--- a/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgePickerView.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgePickerView.swift
@@ -1,0 +1,32 @@
+//
+//  AgePickerView.swift
+//  DesignCore
+//
+//  Created by 김지수 on 11/25/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import SwiftUI
+
+public struct AgePickerView: View {
+    @Binding var selectedValue: String?
+    
+    public init(selectedValue: Binding<String?>) {
+        self._selectedValue = selectedValue
+    }
+    
+    public var body: some View {
+        Picker("숫자 선택", selection: $selectedValue) {
+            Text("상관없어요")
+                .tag(String?.none)
+            ForEach(0...15, id: \.self) { number in
+                Text("\(number)")
+                    .tag(String?(String(number)))
+            }
+        }
+        .pickerStyle(.wheel)
+        .padding(.bottom)
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+    }
+}

--- a/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgeUpDownView.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgeUpDownView.swift
@@ -1,0 +1,113 @@
+//
+//  AgeUpDownView.swift
+//  DesignCore
+//
+//  Created by 김지수 on 11/25/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import SwiftUI
+
+public enum AgeUpDownType {
+    case up
+    case down
+    
+    var imoji: String {
+        switch self {
+        case .up: "👆"
+        case .down: "👇"
+        }
+    }
+    
+    var text: String {
+        switch self {
+        case .up: "위"
+        case .down: "아래"
+        }
+    }
+    
+    var backgroundColor: Color {
+        switch self {
+        case .up: DesignCore.Colors.green50
+        case .down: DesignCore.Colors.pink50
+        }
+    }
+    
+    var borderColor: Color {
+        switch self {
+        case .up: .init(hex: 0xA1BA91)
+        case .down: .init(hex: 0xE6B1C4)
+        }
+    }
+    
+    var textColor: Color {
+        switch self {
+        case .up: DesignCore.Colors.green500
+        case .down: DesignCore.Colors.pink500
+        }
+    }
+}
+
+public struct AgeUpDownView: View {
+    
+    let type: AgeUpDownType
+    
+    private var upperValue: String?
+    private var lowerValue: String?
+    private var showPicker: Bool
+    
+    public init(
+        type: AgeUpDownType,
+        upperValue: String?,
+        lowerValue: String?,
+        showPicker: Bool
+    ) {
+        self.type = type
+        self.upperValue = upperValue
+        self.lowerValue = lowerValue
+        self.showPicker = showPicker
+    }
+    
+    public var body: some View {
+        HStack(spacing: 8) {
+            HStack {
+                Text(type.imoji)
+                Text("내 나이보다")
+                Text(type.text)
+                Text("로")
+            }
+            Spacer()
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .inset(by: 4)
+                    .stroke(
+                        borderColor(),
+                        lineWidth: 10
+                    )
+                    .fill(type.backgroundColor)
+                    .shadow(.default)
+                switch type {
+                case .up:
+                    Text(upperValue ?? "-")
+                        .pretendard(weight: ._600, size: 36)
+                        .foregroundStyle(type.textColor)
+                case .down:
+                    Text(lowerValue ?? "-")
+                        .pretendard(weight: ._600, size: 36)
+                        .foregroundStyle(type.textColor)
+                }
+            }
+            .frame(width: 92, height: 62)
+            .padding(.horizontal, 2)
+            
+            Text("살")
+        }
+        .padding(.horizontal, 8)
+        .foregroundStyle(DesignCore.Colors.grey300)
+        .typography(.semibold_18)
+    }
+    
+    func borderColor() -> Color {
+        return showPicker ? type.borderColor : .white
+    }
+}

--- a/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgeUpDownView.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/AgeUpDownView/AgeUpDownView.swift
@@ -12,7 +12,7 @@ public enum AgeUpDownType {
     case up
     case down
     
-    var imoji: String {
+    var emoji: String {
         switch self {
         case .up: "👆"
         case .down: "👇"
@@ -71,7 +71,7 @@ public struct AgeUpDownView: View {
     public var body: some View {
         HStack(spacing: 8) {
             HStack {
-                Text(type.imoji)
+                Text(type.emoji)
                 Text("내 나이보다")
                 Text(type.text)
                 Text("로")

--- a/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeIntent.swift
+++ b/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeIntent.swift
@@ -1,0 +1,93 @@
+//
+//  EditDateProfileAgeRangeIntent.swift
+//  Home
+//
+//  Created by 김지수 on 11/25/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import Foundation
+import CommonKit
+import CoreKit
+import Model
+import NetworkKit
+import DesignCore
+
+//MARK: - Intent
+class EditDateProfileAgeRangeIntent {
+    private weak var model: EditDateProfileAgeRangeModelActionable?
+    private let input: DataModel
+    private let profileService: ProfileServiceProtocol
+
+    // MARK: Life cycle
+    init(
+        model: EditDateProfileAgeRangeModelActionable,
+        input: DataModel,
+        service: ProfileServiceProtocol = ProfileService.shared
+    ) {
+        self.input = input
+        self.model = model
+        self.profileService = service
+    }
+}
+
+//MARK: - Intentable
+extension EditDateProfileAgeRangeIntent {
+    protocol Intentable {
+        // content
+        func onChangeUpperValue(value: String?)
+        func onChangeLowerValue(value: String?)
+        func onTapNextButton(state: EditDateProfileAgeRangeModel.Stateful)
+        
+        // default
+        func onAppear()
+        func task() async
+    }
+    
+    struct DataModel {
+        let userInfo: UserInfo
+    }
+}
+
+//MARK: - Intentable
+extension EditDateProfileAgeRangeIntent: EditDateProfileAgeRangeIntent.Intentable {
+    // default
+    func onAppear() {}
+    
+    func task() async {}
+    
+    // content
+    func onChangeUpperValue(value: String?) {
+        model?.setUpperValue(value: value)
+    }
+    func onChangeLowerValue(value: String?) {
+        model?.setLowerValue(value: value)
+    }
+    func onTapNextButton(state: EditDateProfileAgeRangeModel.Stateful) {
+        Task {
+            do {
+                guard let upperValue = state.upperValue,
+                      let lowerValue = state.lowerValue else { return }
+                model?.setLoading(status: true)
+                var newUserInfo = input.userInfo
+                newUserInfo.dreamPartner.upperBirthYear = Int(upperValue)
+                newUserInfo.dreamPartner.lowerBirthYear = Int(lowerValue)
+                try await requestUpdatePartnerInfo(newUserInfo: newUserInfo)
+                model?.setLoading(status: false)
+                await popView()
+            } catch {
+                model?.setLoading(status: false)
+                ToastHelper.showErrorMessage(error.localizedDescription)
+            }
+        }
+    }
+    func requestUpdatePartnerInfo(newUserInfo: UserInfo) async throws {
+        try await profileService.requestPutPartnerInfo(
+            userInfo: newUserInfo
+        )
+    }
+    @MainActor
+    func popView() {
+        AppCoordinator.shared.pop()
+    }
+}

--- a/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeModel.swift
+++ b/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeModel.swift
@@ -1,0 +1,91 @@
+//
+//  EditDateProfileAgeRangeModel.swift
+//  Home
+//
+//  Created by 김지수 on 11/25/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import Foundation
+import CommonKit
+import CoreKit
+
+final class EditDateProfileAgeRangeModel: ObservableObject {
+    
+    //MARK: Stateful
+    protocol Stateful {
+        // content
+        var upperValue: String? { get }
+        var lowerValue: String? { get }
+        var isValidated: Bool { get }
+        
+        // default
+        var isLoading: Bool { get }
+        
+        // error
+        var showErrorView: ErrorModel? { get }
+        var showErrorAlert: ErrorModel? { get }
+    }
+    
+    //MARK: State Properties
+    // content
+    var upperValue: String?
+    var lowerValue: String?
+    
+    @Published var isValidated: Bool = false
+    
+    // default
+    @Published var isLoading: Bool = false
+    
+    // error
+    @Published var showErrorView: ErrorModel?
+    @Published var showErrorAlert: ErrorModel?
+}
+
+extension EditDateProfileAgeRangeModel: EditDateProfileAgeRangeModel.Stateful {}
+
+//MARK: - Actionable
+protocol EditDateProfileAgeRangeModelActionable: AnyObject {
+    // content
+    func setUpperValue(value: String?)
+    func setLowerValue(value: String?)
+    func setValidation(value: Bool)
+
+    // default
+    func setLoading(status: Bool)
+    
+    // error
+    func showErrorView(error: ErrorModel)
+    func showErrorAlert(error: ErrorModel)
+    func resetError()
+}
+
+extension EditDateProfileAgeRangeModel: EditDateProfileAgeRangeModelActionable {
+    // content
+    func setUpperValue(value: String?) {
+        upperValue = value
+    }
+    func setLowerValue(value: String?) {
+        lowerValue = value
+    }
+    func setValidation(value: Bool) {
+        isValidated = value
+    }
+    
+    // default
+    func setLoading(status: Bool) {
+        isLoading = status
+    }
+    
+    // error
+    func showErrorView(error: ErrorModel) {
+        showErrorView = error
+    }
+    func showErrorAlert(error: ErrorModel) {
+        showErrorAlert = error
+    }
+    func resetError() {
+        showErrorView = nil
+        showErrorAlert = nil
+    }
+}

--- a/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeView.swift
+++ b/Projects/Features/Home/Sources/DateProfilePanel/EditDateProfile/EditDateProfileAgeRange/EditDateProfileAgeRangeView.swift
@@ -1,0 +1,116 @@
+//
+//  EditDateProfileAgeRangeView.swift
+//  Home
+//
+//  Created by 김지수 on 11/25/24.
+//  Copyright © 2024 com.weave. All rights reserved.
+//
+
+import SwiftUI
+import CoreKit
+import DesignCore
+import CommonKit
+import Model
+
+public struct EditDateProfileAgeRangeView: View {
+    
+    @StateObject var container: MVIContainer<EditDateProfileAgeRangeIntent.Intentable, EditDateProfileAgeRangeModel.Stateful>
+    
+    private var intent: EditDateProfileAgeRangeIntent.Intentable { container.intent }
+    private var state: EditDateProfileAgeRangeModel.Stateful { container.model }
+    
+    public init(userInfo: UserInfo) {
+        let model = EditDateProfileAgeRangeModel()
+        let intent = EditDateProfileAgeRangeIntent(
+            model: model,
+            input: .init(userInfo: userInfo)
+        )
+        let container = MVIContainer(
+            intent: intent as EditDateProfileAgeRangeIntent.Intentable,
+            model: model as EditDateProfileAgeRangeModel.Stateful,
+            modelChangePublisher: model.objectWillChange
+        )
+        self._container = StateObject(wrappedValue: container)
+    }
+    
+    @State private var upperValue: String?
+    @State private var lowerValue: String?
+    @State private var showUpperPicker = true
+    @State private var showLowerPicker = false
+    
+    public var body: some View {
+        ZStack {
+            VStack {
+                AgeUpDownView(
+                    type: .up,
+                    upperValue: upperValue,
+                    lowerValue: lowerValue,
+                    showPicker: showUpperPicker
+                )
+                .onTapGesture {
+                    showUpperPicker = true
+                    showLowerPicker = false
+                }
+                AgeUpDownView(
+                    type: .down,
+                    upperValue: upperValue,
+                    lowerValue: lowerValue,
+                    showPicker: showLowerPicker
+                )
+                .onTapGesture {
+                    showUpperPicker = false
+                    showLowerPicker = true
+                }
+                
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 40)
+            
+            if showUpperPicker || showLowerPicker {
+                VStack {
+                    Spacer()
+                    AgePickerView(
+                        selectedValue: showUpperPicker ? $upperValue : $lowerValue
+                    )
+                    .padding(.bottom, 90)
+                    .frame(height: 300)
+                }
+                .transition(.move(edge: .bottom))
+                .ignoresSafeArea()
+            }
+            
+            VStack {
+                Spacer()
+                CTABottomButton(title: "다음") {
+                    intent.onTapNextButton(state: state)
+                }
+            }
+        }
+        .onChange(of: upperValue) {
+            intent.onChangeUpperValue(value: upperValue)
+        }
+        .onChange(of: lowerValue) {
+            intent.onChangeLowerValue(value: lowerValue)
+        }
+        .task {
+            await intent.task()
+        }
+        .onAppear {
+            intent.onAppear()
+        }
+        .navigationTitle("선호 연령 수정")
+        .ignoresSafeArea(.keyboard)
+        .textureBackground()
+        .setPopNavigation {
+            AppCoordinator.shared.pop()
+        }
+        .setLoading(state.isLoading)
+    }
+}
+
+#Preview {
+    NavigationView {
+        EditDateProfileAgeRangeView(userInfo: .mock)
+    }
+}

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
@@ -88,16 +88,26 @@ public struct DreamPartnerAgeView: View {
                     mainMessage: "상대의 나이대는\n어느 정도가 좋을까요?"
                 ) {
                     VStack {
-                        ageUpDownView(type: .up)
-                            .onTapGesture {
-                                showUpperPicker = true
-                                showLowerPicker = false
-                            }
-                        ageUpDownView(type: .down)
-                            .onTapGesture {
-                                showUpperPicker = false
-                                showLowerPicker = true
-                            }
+                        AgeUpDownView(
+                            type: .up,
+                            upperValue: upperValue,
+                            lowerValue: lowerValue,
+                            showPicker: showUpperPicker
+                        )
+                        .onTapGesture {
+                            showUpperPicker = true
+                            showLowerPicker = false
+                        }
+                        AgeUpDownView(
+                            type: .down,
+                            upperValue: upperValue,
+                            lowerValue: lowerValue,
+                            showPicker: showLowerPicker
+                        )
+                        .onTapGesture {
+                            showUpperPicker = false
+                            showLowerPicker = true
+                        }
                     }
                 }
                 
@@ -106,7 +116,7 @@ public struct DreamPartnerAgeView: View {
             if showUpperPicker || showLowerPicker {
                 VStack {
                     Spacer()
-                    BottomSheetPickerView(
+                    AgePickerView(
                         selectedValue: showUpperPicker ? $upperValue : $lowerValue
                     )
                     .padding(.bottom, 90)
@@ -141,72 +151,6 @@ public struct DreamPartnerAgeView: View {
             AppCoordinator.shared.pop()
         }
         .setLoading(state.isLoading)
-    }
-    
-    @ViewBuilder
-    func ageUpDownView(type: AgeUpDownType) -> some View {
-        HStack(spacing: 8) {
-            HStack {
-                Text(type.imoji)
-                Text("내 나이보다")
-                Text(type.text)
-                Text("로")
-            }
-            Spacer()
-            ZStack {
-                RoundedRectangle(cornerRadius: 16)
-                    .inset(by: 4)
-                    .stroke(
-                        borderColor(type: type),
-                        lineWidth: 10
-                    )
-                    .fill(type.backgroundColor)
-                    .shadow(.default)
-                switch type {
-                case .up:
-                    Text(upperValue ?? "-")
-                        .pretendard(weight: ._600, size: 36)
-                        .foregroundStyle(type.textColor)
-                case .down:
-                    Text(lowerValue ?? "-")
-                        .pretendard(weight: ._600, size: 36)
-                        .foregroundStyle(type.textColor)
-                }
-            }
-            .frame(width: 92, height: 62)
-            .padding(.horizontal, 2)
-            
-            Text("살")
-        }
-        .padding(.horizontal, 8)
-        .foregroundStyle(DesignCore.Colors.grey300)
-        .typography(.semibold_18)
-    }
-    
-    func borderColor(type: AgeUpDownType) -> Color {
-        switch type {
-        case .up: showUpperPicker ? type.borderColor : .white
-        case .down: showLowerPicker ? type.borderColor : .white
-        }
-    }
-}
-
-struct BottomSheetPickerView: View {
-    @Binding var selectedValue: String?
-    
-    var body: some View {
-        Picker("숫자 선택", selection: $selectedValue) {
-            Text("상관없어요")
-                .tag(String?.none)
-            ForEach(0...15, id: \.self) { number in
-                Text("\(number)")
-                    .tag(String?(String(number)))
-            }
-        }
-        .pickerStyle(.wheel)
-        .padding(.bottom)
-        .background(Color(.systemBackground))
-        .cornerRadius(16)
     }
 }
 

--- a/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
+++ b/Projects/Features/SignUp/Sources/DreamPartnerInput/DreamPartnerAge/DreamPartnerAgeView.swift
@@ -16,7 +16,7 @@ enum AgeUpDownType {
     case up
     case down
     
-    var imoji: String {
+    var emoji: String {
         switch self {
         case .up: "👆"
         case .down: "👇"

--- a/Projects/Model/Model/Sources/Auth/Domain/UserInfo.swift
+++ b/Projects/Model/Model/Sources/Auth/Domain/UserInfo.swift
@@ -156,8 +156,8 @@ public struct DreamPartnerInfo: Equatable, Hashable {
         if lhs.allowSameCompany != rhs.allowSameCompany { return false }
         return true
     }
-    public let upperBirthYear: Int?
-    public let lowerBirthYear: Int?
+    public var upperBirthYear: Int?
+    public var lowerBirthYear: Int?
     public let jobOccupations: [String]
     public let distanceType: DreamPartnerDistanceType
     public var allowSameCompany: Bool?


### PR DESCRIPTION
## 구현사항
- 이상형 프로필 - 선호 연령대 수정 기능 구현
- API 제외

## 스크린샷(선택)
|이상형 프로필 수정|
|:---:|
|<img src="https://github.com/user-attachments/assets/727c6ae9-32a8-44d4-9829-1be984cb55de" width="400">|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 나이 범위를 편집할 수 있는 UI 컴포넌트 추가.
  - 사용자 프로필의 나이 정보를 요청하는 비동기 메소드 추가.
  - 나이 선택을 위한 `AgePickerView` 및 `AgeUpDownView` 컴포넌트 도입.
  - `EditDateProfileAgeRangeView` 컴포넌트 추가로 사용자 프로필의 나이 범위 편집 기능 강화.

- **버그 수정**
  - 인증 상태 변경 시 불필요한 업데이트 방지 로직 개선.

- **문서화**
  - 새로운 프로토콜 및 클래스에 대한 설명 추가.

- **리팩토링**
  - `DreamPartnerAgeView`에서 나이 선택 로직 간소화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->