### PR TITLE
[WEAV-160] 채팅 뷰 pagination 처리

### DIFF
--- a/Projects/Core/NetworkKit/Sources/ChatService/ChatService.swift
+++ b/Projects/Core/NetworkKit/Sources/ChatService/ChatService.swift
@@ -40,7 +40,6 @@ extension ChatService: ChatServiceProtocol {
             )
         )
             .ok.body.json
-        response.messages?.reverse()
         return MessageList(from: response)
     }
 }

--- a/Projects/Core/NetworkKit/Sources/NetworkCore/ServerType.swift
+++ b/Projects/Core/NetworkKit/Sources/NetworkCore/ServerType.swift
@@ -16,18 +16,18 @@ public enum ServerType: String {
     var baseURL: String {
         switch self {
         case .dev:
-            return "http://\(Secret.devBaseUrl)"
+            return "https://\(Secret.devBaseUrl)"
         case .prod:
-            return "http://\(Secret.prodBaseUrl)"
+            return "https://\(Secret.prodBaseUrl)"
         }
     }
     
     var socketBaseUrl: String {
         switch self {
         case .dev:
-            return "ws://\(Secret.devBaseUrl)/ws"
+            return "wss://\(Secret.devBaseUrl)/ws"
         case .prod:
-            return "ws://\(Secret.prodBaseUrl)/ws"
+            return "wss://\(Secret.prodBaseUrl)/ws"
         }
     }
     

--- a/Projects/DesignSystem/DesignCore/Sources/FlipUpsideDown/FlipUpsideDown.swift
+++ b/Projects/DesignSystem/DesignCore/Sources/FlipUpsideDown/FlipUpsideDown.swift
@@ -1,0 +1,23 @@
+//
+//  FlipUpsideDown.swift
+//  DesignCore
+//
+//  Created by 김지수 on 3/8/25.
+//  Copyright © 2025 com.weave. All rights reserved.
+//
+
+import SwiftUI
+
+fileprivate struct FlippedUpsideDown: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(Angle(degrees: 180))
+            .scaleEffect(x: -1.0, y: 1.0, anchor: .center)
+    }
+}
+
+public extension View{
+    func flippedUpsideDown() -> some View{
+        self.modifier(FlippedUpsideDown())
+    }
+}

--- a/Projects/Features/Chat/Sources/ChatComponents/ChatMessageListView.swift
+++ b/Projects/Features/Chat/Sources/ChatComponents/ChatMessageListView.swift
@@ -20,51 +20,64 @@ public struct ChatMessageListView: View {
     
     var sendAction: () -> Void
     var nextPageAction: () -> Void
+    @State var lastSectionId: String?
     
     @FocusState var isTextFieldFocused
     
     public var body: some View {
         VStack(spacing: 0) {
-            ScrollView {
-                LazyVStack(spacing: 10) {
-                    
-                    // pagination
-                    if hasNextPage {
-                        ProgressView()
-                            .onAppear {
-                                nextPageAction()
-                            }
-                    }
-                    
-                    ForEach(messageDataSource.toSectionItmes) { section in
-                        LazyVStack(spacing: 2) {
-                            switch section {
-                            case .dateSeperator(let date):
-                                dateSeperator(date)
-                            case .messages(let dataSource):
-                                messageSection(dataSource)
-                            }
+            List {
+                ForEach(messageDataSource.toSectionItmes) { section in
+                    LazyVStack(spacing: 2) {
+                        switch section {
+                        case .dateSeperator(let date):
+                            dateSeperator(date)
+                        case .messages(let dataSource):
+                            messageSection(dataSource)
                         }
                     }
+                    .id(section.id)
+                    .onAppear {
+                        self.lastSectionId = section.id
+                    }
+                    .flippedUpsideDown()
                 }
-                .rotationEffect(Angle(degrees: 180))
-                .scaleEffect(x: -1.0, y: 1.0, anchor: .center)
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init())
+                .listRowSeparator(.hidden)
                 .padding(.horizontal, 18)
                 .padding(.vertical, 8)
+                
+                if hasNextPage {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                    .id(UUID().uuidString)
+                    .flippedUpsideDown()
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(.init())
+                    .listRowSeparator(.hidden)
+                    .onAppear {
+                        nextPageAction()
+                    }
+                }
             }
-            .rotationEffect(Angle(degrees: 180))
-            .scaleEffect(x: -1.0, y: 1.0, anchor: .center)
-            .scrollDismissesKeyboard(.interactively)
+            .scrollContentBackground(.hidden)
+            .scrollDismissesKeyboard(.immediately)
+            .listStyle(PlainListStyle())
+            .flippedUpsideDown()
             .onTapGesture {
                 isTextFieldFocused = false
             }
-            
-            ChatInputContainerView(
-                inputText: $inputText,
-                isTextFieldFocused: _isTextFieldFocused,
-                sendAction: sendAction
-            )
         }
+        
+        ChatInputContainerView(
+            inputText: $inputText,
+            isTextFieldFocused: _isTextFieldFocused,
+            sendAction: sendAction
+        )
     }
     
     //MARK: - Date Seperator: 날짜 구분 컴포넌트

--- a/Projects/Features/Chat/Sources/ChatContainerView/ChatContainerModel.swift
+++ b/Projects/Features/Chat/Sources/ChatContainerView/ChatContainerModel.swift
@@ -82,17 +82,19 @@ extension ChatContainerModel: ChatContainerModelActionable {
     }
     func appendMessageList(message: MessageList) {
         let oldMessages = messageDataSource.messages
-        var newMessages = message.messages
-        newMessages.append(contentsOf: oldMessages)
-        messageDataSource.messages = newMessages
-        messageDataSource.nextCursor = message.nextCursor
-        messageDataSource.hasNext = message.hasNext
+        var newMessages = oldMessages
+        newMessages.append(contentsOf: message.messages)
+        var newDataSource = messageDataSource
+        newDataSource.messages = newMessages
+        newDataSource.nextCursor = message.nextCursor
+        newDataSource.hasNext = message.hasNext
+        messageDataSource = newDataSource
     }
     func setSocketStatus(isConnected: Bool) {
         isSocketConnected = isConnected
     }
     func socketReceivedNewMessage(message: Message) {
-        messageDataSource.messages.append(message)
+        messageDataSource.messages.insert(message, at: 0)
     }
     
     // default

--- a/Projects/Model/Model/Sources/Chat/Domain/ChatMessageItemType.swift
+++ b/Projects/Model/Model/Sources/Chat/Domain/ChatMessageItemType.swift
@@ -48,7 +48,7 @@ extension Array where Element == Message {
                     date2: message.createdAt
                 )
             {
-                currentGroup.append(message)
+                currentGroup.insert(message, at: 0)
             }
             else
             {
@@ -56,7 +56,7 @@ extension Array where Element == Message {
                 if currentGroup.isNotEmpty {
                     let messageGroup = updateBubbleTypes(for: currentGroup)
                     result.append(.messages(dateSource: messageGroup))
-                    lastMessage = currentGroup.last
+                    lastMessage = currentGroup.first
                     currentGroup = []
                 }
                 
@@ -74,8 +74,15 @@ extension Array where Element == Message {
         
         if currentGroup.isNotEmpty {
             result.append(.messages(dateSource: currentGroup))
+            if let lastDate = currentGroup.last?.createdAt {
+                let format = "M월 d일 (EEE)"
+                let seperator = DateConverter.dateToString(
+                    date: lastDate,
+                    format: format
+                )
+                result.append(.dateSeperator(date: seperator))
+            }
         }
-
         return result
     }
     
@@ -105,13 +112,8 @@ extension Array where Element == Message {
         new: Date?
     ) -> String? {
         let format = "M월 d일 (EEE)"
-        guard let new else { return nil }
-        guard let previous else {
-            return DateConverter.dateToString(
-                date: new,
-                format: format
-            )
-        }
+        guard let new,
+              let previous else { return nil }
         let previousDate = DateConverter.dateToString(
             date: previous,
             format: format
@@ -121,7 +123,7 @@ extension Array where Element == Message {
             format: format
         )
         if previousDate != newDate {
-            return newDate
+            return previousDate
         }
         return nil
     }


### PR DESCRIPTION
## 구현사항
- 채팅 content 리스트 뷰에 pagination 기능 추가
- LazyVStack -> List 로 뷰 구조 변경

## 스크린샷(선택)
|페이징|
|:---:|
|<img src="https://github.com/user-attachments/assets/543e3d63-4ce8-4c87-b9b9-7faae84adfea" width="400">|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UI에 적용 가능한 새로운 뒤집힌 전환 기능을 추가하였습니다.
  
- **Refactor**
  - 채팅 인터페이스의 메시지 순서 및 그룹 처리 방식을 재구성하여 보다 자연스러운 대화 흐름을 제공합니다.
  - 스크롤, 페이지네이션 및 키보드 해제 동작이 개선되어 사용자 경험이 향상되었습니다.
  
- **Chores**
  - 서버와 소켓 연결의 보안을 강화하기 위해 URL 프로토콜이 안전한 버전으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->